### PR TITLE
DarkRP Support

### DIFF
--- a/lua/autorun/cl_chat.lua
+++ b/lua/autorun/cl_chat.lua
@@ -368,11 +368,13 @@ function chat.AddText(...)
 	
 	eChat.chatLog:SetVisible( true )
 	eChat.lastMessage = CurTime()
+	oldAddText(unpack(msg))
 
 	-- Print the chat message to console like the regular function
 	MsgC( unpack(msg) )
 	MsgC("\n")
 end
+
 
 --// Write any server notifications
 hook.Add( "ChatText", "echat_joinleave", function( index, name, text, type )
@@ -415,4 +417,72 @@ hook.Add("HUDShouldDraw", "echat_hidedefault", function( name )
 	end
 end)
 
+--// Modify the Chatbox for align.
+local oldGetChatBoxPos = chat.GetChatBoxPos
+function chat.GetChatBoxPos()
+	local x = 30
+	local y = ScrH() - eChat.frame:GetTall() * 1.7
+	
+	return x,y
+end
 
+
+--// Overriding FPRP Stupid Chat System. The Glorious DarkRP Masterrace got it also working, to shine over the fprp peasants.
+local function override_darkrp()
+--// Detouring the DarkRP Chat to use the old system
+local function AddToChat(bits)
+	local col1 = Color(net.ReadUInt(8), net.ReadUInt(8), net.ReadUInt(8))
+
+	local prefixText = net.ReadString()
+	local ply = net.ReadEntity()
+	ply = IsValid(ply) and ply or LocalPlayer()
+
+	if prefixText == "" or not prefixText then
+		prefixText = ply:Nick()
+		prefixText = prefixText ~= "" and prefixText or ply:SteamName()
+	end
+
+	local col2 = Color(net.ReadUInt(8), net.ReadUInt(8), net.ReadUInt(8))
+
+	local text = net.ReadString()
+	local shouldShow
+	if text and text ~= "" then
+		if IsValid(ply) then
+			shouldShow = hook.Call("OnPlayerChat", GAMEMODE, ply, text, false, not ply:Alive(), prefixText, col1, col2)
+		end
+
+		if shouldShow ~= true then
+			chat.AddText(col1, prefixText, col2, ": "..text)
+		end
+	else
+		--shouldShow = hook.Call("ChatText", GAMEMODE, "0", prefixText, prefixText, "none")
+		--if shouldShow ~= true then
+			chat.AddText(col1, prefixText)
+		--end
+	end
+	chat.PlaySound()
+end
+net.Receive("DarkRP_Chat", AddToChat)
+--// Reverting the OnPlayerChat changes. Praise FPtje!
+function GAMEMODE:OnPlayerChat(ply, strText, bTeamOnly, bPlayerIsDead )
+	local tab = {}
+	if ( bPlayerIsDead ) then
+		table.insert( tab, Color( 255, 30, 40 ) )
+		table.insert( tab, "*DEAD* " )
+	end
+	if ( bTeamOnly ) then
+		table.insert( tab, Color( 30, 160, 40 ) )
+		table.insert( tab, "(TEAM) " )
+	end
+	if ( IsValid( ply ) ) then
+		table.insert( tab, ply )
+	else
+		table.insert( tab, "Console" )
+	end
+	table.insert( tab, Color( 255, 255, 255 ) )
+	table.insert( tab, ": " .. strText )
+	chat.AddText( unpack(tab) )
+	return true
+	end
+end
+hook.Add("Initialize", "eChats_DerpRP_comp", override_darkrp)		


### PR DESCRIPTION
So that the glorious DarkRP Masterrace can use your Chatbox, but also
adds in peasantry fprp support.

in detail:
Retouring chat.GetChatBoxPos, so the "no one can hear you" can be properly drawn
Recreating the DarkRP Chat Handler and duplicating it, so it get added correctly in the chatbox.
Reviving the OnPlayerChat for proper hooking.

i know that the chatcommands are broken. fix coming tomorrow.
